### PR TITLE
Add support for "rolling" calculations

### DIFF
--- a/mosaic/mosaic.py
+++ b/mosaic/mosaic.py
@@ -91,7 +91,7 @@ def run(args, client=None):
     check_queries(args['query'])
     queries = []
     for query in args['query']:
-        queries.append(query_map[query](query, client, query_vars))
+        queries.append(query_map[query](query, client, query_vars, log))
 
     for query in queries:
         query.set_defaults()

--- a/mosaic/mosaic.py
+++ b/mosaic/mosaic.py
@@ -21,18 +21,31 @@ def parse_args():
     parser = argparse.ArgumentParser()
 
     parser.add_argument('-s', '--server',
-                        default='https://projects.engineering.redhat.com')
+                        default='https://projects.engineering.redhat.com',
+                        help='The JIRA server to connect to')
     parser.add_argument('-c', '--cert',
-                        default='/etc/pki/tls/certs/ca-bundle.crt')
-    parser.add_argument('-p', '--project', default='FACTORY')
+                        default='/etc/pki/tls/certs/ca-bundle.crt',
+                        help=('The path to the certification bundle to use '
+                              'when connecting to the JIRA server'))
+    parser.add_argument('-p', '--project', default='FACTORY',
+                        help='The JIRA project to get metrics for')
 
     today = datetime.date.today()
     two_weeks_ago = today - datetime.timedelta(days=14)
-    parser.add_argument('-b', '--begin-date', default=str(two_weeks_ago))
-    parser.add_argument('-e', '--end-date', default=str(today))
+    parser.add_argument('-b', '--begin-date', default=str(two_weeks_ago),
+                        help=('The beginning of the date range to calculate '
+                              'metrics for'))
+    parser.add_argument('-e', '--end-date', default=str(today),
+                        help=('The end of the date range to calculate '
+                              'metrics for'))
 
-    parser.add_argument('-q', '--query', action='append')
-    parser.add_argument('-a', '--query-argument', default=None)
+    parser.add_argument('-q', '--query', action='append',
+                        help=('The query to execute. Specify multiple '
+                              'arguments by repeating this argument'))
+    parser.add_argument('-a', '--query-argument', default=None,
+                        help=('The argument to be passed to the query. This '
+                              'will be passed to all queries if multiple are '
+                              'specified'))
     parser.add_argument('-v', '--verbose', default=False,
                         action='store_true',
                         help='Enable debug logging')

--- a/mosaic/mosaic.py
+++ b/mosaic/mosaic.py
@@ -50,7 +50,14 @@ def parse_args():
                         action='store_true',
                         help='Enable debug logging')
     parser.add_argument('-l', '--list', action='store_true',
+                        default=False,
                         help='Print a list of available queries')
+    parser.add_argument('-r', '--rolling', action='store_true',
+                        default=False,
+                        help=('Use data for currently in progress stories '
+                              'when performing calculations for date ranges '
+                              'that include today. Not supported by all '
+                              'queries'))
 
     return vars(parser.parse_args())
 
@@ -77,7 +84,8 @@ def run(args, client=None):
         'project': args['project'],
         'begin_date': args['begin_date'],
         'end_date': args['end_date'],
-        'argument': args['query_argument']
+        'argument': args['query_argument'],
+        'rolling': args['rolling']
     }
 
     check_queries(args['query'])
@@ -110,7 +118,7 @@ def main():
         queries = ', '.join(query_map.keys())
         log.info(msg.format(queries=queries))
         sys.exit(0)
-    elif 'queries' not in args or len(args['queries']) == 0:
+    elif 'query' not in args or len(args['query']) == 0:
         msg = 'You must specify at least one query with the -q argument.'
         log.error(msg)
         sys.exit(1)

--- a/mosaic/mosaic.py
+++ b/mosaic/mosaic.py
@@ -4,6 +4,7 @@ import argparse
 import datetime
 import jira
 import logging
+import sys
 
 from .queries import query_map
 
@@ -30,11 +31,13 @@ def parse_args():
     parser.add_argument('-b', '--begin-date', default=str(two_weeks_ago))
     parser.add_argument('-e', '--end-date', default=str(today))
 
-    parser.add_argument('-q', '--query', required=True, action='append')
+    parser.add_argument('-q', '--query', action='append')
     parser.add_argument('-a', '--query-argument', default=None)
     parser.add_argument('-v', '--verbose', default=False,
                         action='store_true',
                         help='Enable debug logging')
+    parser.add_argument('-l', '--list', action='store_true',
+                        help='Print a list of available queries')
 
     return vars(parser.parse_args())
 
@@ -89,6 +92,15 @@ def main():
     else:
         log.setLevel(logging.INFO)
 
+    if args['list']:
+        msg = 'The following queries are supported: [{queries}]'
+        queries = ', '.join(query_map.keys())
+        log.info(msg.format(queries=queries))
+        sys.exit(0)
+    elif 'queries' not in args or len(args['queries']) == 0:
+        msg = 'You must specify at least one query with the -q argument.'
+        log.error(msg)
+        sys.exit(1)
     run(args)
 
 

--- a/mosaic/mosaic.py
+++ b/mosaic/mosaic.py
@@ -8,6 +8,14 @@ import logging
 from .queries import query_map
 
 
+log = logging.getLogger('mosaic')
+ch = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter(('%(asctime)s - %(name)s - '
+                               '%(levelname)s - %(message)s'))
+ch.setFormatter(formatter)
+log.addHandler(ch)
+
+
 def parse_args():
     parser = argparse.ArgumentParser()
 
@@ -77,9 +85,10 @@ def run(args, client=None):
 def main():
     args = parse_args()
     if args['verbose']:
-        logging.basicConfig(level=logging.DEBUG)
+        log.setLevel(logging.DEBUG)
     else:
-        logging.basicConfig(level=logging.INFO)
+        log.setLevel(logging.INFO)
+
     run(args)
 
 

--- a/mosaic/queries/BaseQuery.py
+++ b/mosaic/queries/BaseQuery.py
@@ -1,12 +1,30 @@
+import datetime
 import logging
 
 
 class BaseQuery(object):
+    supports_rolling = False
+
     def __init__(self, query_name, client, vars):
         self.query_name = query_name
         self.client = client
         self.vars = vars
         self.result = None
+        self.rolling = vars['rolling']
+        if self.rolling:
+            if not self.supports_rolling:
+                msg = ('The specified query: "{query}" does not support the '
+                       'rolling argument.').format(query=self.query_name)
+                raise Exception(msg)
+            today = datetime.date.today()
+            begin_date = datetime.datetime.strptime(vars['begin_date'],
+                                                    '%Y-%m-%d')
+            end_date = datetime.datetime.strptime(vars['end_date'],
+                                                  '%Y-%m-%d')
+            if not (today >= begin_date.date() and today <= end_date.date()):
+                msg = ('The rolling argument can only be used for date ranges '
+                       'that include today.')
+                raise Exception(msg)
 
     def build_query(self):
         self.queries = {}

--- a/mosaic/queries/BaseQuery.py
+++ b/mosaic/queries/BaseQuery.py
@@ -1,11 +1,11 @@
 import datetime
-import logging
 
 
 class BaseQuery(object):
     supports_rolling = False
 
-    def __init__(self, query_name, client, vars):
+    def __init__(self, query_name, client, vars, log):
+        self.log = log
         self.query_name = query_name
         self.client = client
         self.vars = vars
@@ -39,7 +39,7 @@ class BaseQuery(object):
     def run(self):
         self.results = {}
         for query, query_string in self.queries.items():
-            logging.debug('Executing query: {0}'.format(query_string))
+            self.log.debug('Executing query: {0}'.format(query_string))
             self.results[query] = self.client.search_issues(query_string,
                                                             expand='changelog',
                                                             maxResults=False)

--- a/mosaic/queries/CycletimeQuery.py
+++ b/mosaic/queries/CycletimeQuery.py
@@ -1,4 +1,4 @@
-import logging
+import datetime
 import traceback
 
 from .BaseQuery import BaseQuery
@@ -6,12 +6,16 @@ from .utils import date_difference
 
 
 class CycletimeQuery(BaseQuery):
+    supports_rolling = True
     query_bases = {
         'cycletime': ('PROJECT = {project} '
                       'AND TYPE IN ({types}) '
                       'AND statusCategory = Done '
                       'AND status CHANGED TO Done '
-                      'DURING("{begin_date}", "{end_date}")')
+                      'DURING("{begin_date}", "{end_date}")'),
+        'cycletime_rolling': ('PROJECT = {project} '
+                              'AND TYPE IN ({types}) '
+                              'AND statusCategory = "In Progress" ')
     }
 
     def set_defaults(self):
@@ -38,26 +42,46 @@ class CycletimeQuery(BaseQuery):
         cycle_time = date_difference(issue.fields.resolutiondate,
                                      start_date)
         line = '\tFor issue {issue}, the cycle time was {cycletime} days'
-        logging.debug(line.format(issue=issue.key, cycletime=cycle_time))
+        self.log.debug(line.format(issue=issue.key, cycletime=cycle_time))
         return cycle_time
 
-    def _get_total_cycle_time(self, issues):
+    def _get_total_cycle_time(self, issues, in_progress_issues):
         count = len(issues)
         total_cycle_time = 0
         for issue in issues:
             try:
                 total_cycle_time += self._get_issue_cycle_time(issue)
             except Exception:
-                logging.debug(traceback.format_exc())
-                count = count - 1
+                self.log.debug(traceback.format_exc())
+                count -= 1
+        if self.rolling:
+            self.log.debug(('Calculating time spent so far for in '
+                            'progress issues'))
+            today = datetime.date.today()
+            today = datetime.datetime.strftime(today, '%Y-%m-%d')
+            for issue in in_progress_issues:
+                start_date = self._get_issue_start_date(issue)
+                time_spent = date_difference(today, start_date)
+                self.log.debug(('Time spent so far on issue {key}: {duration} '
+                                'days.').format(key=issue.key,
+                                                duration=time_spent))
+                total_cycle_time += time_spent
+                count += 1
 
         average_cycle_time = total_cycle_time / count
         return average_cycle_time
 
     def build_results(self):
         issues = self.results['cycletime']
-        logging.debug('There were {0} issues'.format(len(issues)))
-        average_cycle_time = self._get_total_cycle_time(issues)
+        in_progress_issues = self.results['cycletime_rolling']
+        self.log.debug('There were {0} issues'.format(len(issues)))
+        if self.rolling:
+            self.log.debug(('Rolling argument specified. Cycle time will be '
+                           'calculated using in progress issues'))
+            self.log.debug(('There are {len} issues in '
+                           'progress.').format(len=len(in_progress_issues)))
+        average_cycle_time = self._get_total_cycle_time(issues,
+                                                        in_progress_issues)
         self.result = average_cycle_time
         start_date = self.vars['begin_date']
         end_date = self.vars['end_date']

--- a/mosaic/queries/ThroughputQuery.py
+++ b/mosaic/queries/ThroughputQuery.py
@@ -1,5 +1,3 @@
-import logging
-
 from .BaseQuery import BaseQuery
 from .utils import by_epic
 
@@ -39,8 +37,7 @@ class ThroughputbyepicQuery(ThroughputQuery):
 
         unassigned_issues = ', '.join(issue.key for issue in epics['UNASSIGNED'])
         msg = 'The following issues were not assigned to an epic: {0}'
-        logging.debug(msg.format(unassigned_issues))
-
+        self.log.debug(msg.format(unassigned_issues))
 
         self.results_report = 'Number of issues completed by epic:\n\n'
         epic_line = '\t{epic}: {throughput} issues\n'


### PR DESCRIPTION
When the -r (--rolling) argument is specified, if the query supports it and the specified date range includes today, then in-progress issues will be included in the calculation.