### PR TITLE
Always get a default value for the types argument

### DIFF
--- a/mosaic/mosaic.py
+++ b/mosaic/mosaic.py
@@ -16,6 +16,8 @@ formatter = logging.Formatter(('%(asctime)s - %(name)s - '
 ch.setFormatter(formatter)
 log.addHandler(ch)
 
+DEFAULT_TYPES = 'bug, story, task'
+
 
 def parse_args():
     desc = 'A utility for calculating various metrics from JIRA data'
@@ -62,7 +64,7 @@ def parse_args():
     parser.add_argument('--query-append', default='',
                         help=('An additional string to be appended to all '
                               'JIRA search queries'))
-    parser.add_argument('-t', '--types', default='bug, story, task',
+    parser.add_argument('-t', '--types', default=DEFAULT_TYPES,
                         help=('An optional comma separated string argument '
                               'to query for specific types of tickets '
                               'eg:\'bug, story\' '))
@@ -95,7 +97,7 @@ def run(args, client=None):
         'argument': args['query_argument'],
         'rolling': args.get('rolling', False),
         'query_append': args.get('query_append', ''),
-        'types': args['types']
+        'types': args.get('types', DEFAULT_TYPES)
     }
 
     check_queries(args['query'])


### PR DESCRIPTION
When finishline calls Mosaic, it passes in an args dict that bypasses
the default argument parsing that you get when you call mosaic directly.
This means that we have to be carful with how we handle which arguments
are required, and generally need to ensure that a default value always
is applied for any required arguments.