### PR TITLE
Build lead and cycle time from float values.

### DIFF
--- a/mosaic/queries/LeadtimeQuery.py
+++ b/mosaic/queries/LeadtimeQuery.py
@@ -1,7 +1,5 @@
-import datetime
-
 from .BaseQuery import BaseQuery
-from .utils import by_epic
+from .utils import by_epic, date_difference
 
 
 class LeadtimeQuery(BaseQuery):
@@ -17,14 +15,12 @@ class LeadtimeQuery(BaseQuery):
         if 'types' not in self.vars:
             self.vars['types'] = 'bug, story, task'
 
-    def _get_date(self, date_string):
-        return datetime.datetime.strptime(date_string[0:10],
-                                          '%Y-%m-%d')
-
     def _get_issue_lead_time(self, issue):
-        created_date = self._get_date(issue.fields.created)
-        resolution_date = self._get_date(issue.fields.resolutiondate)
-        return (resolution_date - created_date).days
+        lead_time = date_difference(
+            issue.fields.resolutiondate, issue.fields.created)
+        line = '\tFor issue {issue}, the lead time was {leadtime} days'
+        self.log.debug(line.format(issue=issue.key, leadtime=lead_time))
+        return lead_time
 
     def _get_issues_lead_time(self, issues):
         total_lead_time = 0

--- a/mosaic/queries/utils.py
+++ b/mosaic/queries/utils.py
@@ -22,12 +22,13 @@ def by_epic(issues):
 
 
 def date_difference(later_date, earlier_date):
-    date_format = '%Y-%m-%d'
-    later_date = later_date[0:10]
-    earlier_date = earlier_date[0:10]
+    date_format = '%Y-%m-%dT%H:%M:%S'
+    later_date = later_date[0:19]
+    earlier_date = earlier_date[0:19]
     later_date_object = datetime.datetime.strptime(later_date,
                                                    date_format)
     earlier_date_object = datetime.datetime.strptime(earlier_date,
                                                      date_format)
-    difference = (later_date_object - earlier_date_object).days
-    return difference
+    difference = (later_date_object - earlier_date_object).total_seconds()
+    # Convert difference to days.
+    return difference / float(60 * 60 * 24)


### PR DESCRIPTION
Previously, we were building these from integer day counts, which could
just be 0.  This gives us a little more precision in the value.