### PR TITLE
Provide a default value when used as a lib.

### DIFF
--- a/mosaic/mosaic.py
+++ b/mosaic/mosaic.py
@@ -109,7 +109,7 @@ def run(args, client=None):
         'types': quoted_types,
     }
 
-    renderer = renderer_map[args['output']]
+    renderer = renderer_map[args.get('output', 'text')]
 
     check_queries(args['query'])
     queries = []


### PR DESCRIPTION
When used as a library, argparse is never invoked to provide the default.