### PR TITLE
Don't double count issues in isolated rolling mode.

### DIFF
--- a/mosaic/queries/StatusdurationQuery.py
+++ b/mosaic/queries/StatusdurationQuery.py
@@ -97,18 +97,19 @@ class StatusdurationQuery(BaseQuery):
         self.log.debug(('{len} issues were completed during the target '
                         'date range.').format(len=issues))
         total_duration = 0
-        for issue in self.results['statusduration']:
-            duration = self._get_time_in_status(issue, target_status)
-            if duration < 0:
-                issues = issues - 1
-            else:
-                self.log.debug(('Time spent in status "{status}" for issue '
-                                '"{key}: {duration} '
-                                'days').format(status=target_status,
-                                               key=issue.key,
-                                               duration=duration))
-                total_duration += duration
-        if self.rolling:
+        if not self.rolling:
+            for issue in self.results['statusduration']:
+                duration = self._get_time_in_status(issue, target_status)
+                if duration < 0:
+                    issues = issues - 1
+                else:
+                    self.log.debug(('Time spent in status "{status}" for '
+                                    'issue {key}: {duration} '
+                                    'days').format(status=target_status,
+                                                   key=issue.key,
+                                                   duration=duration))
+                    total_duration += duration
+        else:
             self.log.debug(('Rolling argument specified. Issues in progress '
                             'will be used to calculate status duration.'))
             self.log.debug(('{len} issues are currently in '


### PR DESCRIPTION
This changes the behavior such that issues found that were closed *during* the
given time period are not double counted when looking at the rolling
calculation for that period.

Should be more accurate.