### PR TITLE
Allow excluding some issues by bounding duration.

### DIFF
--- a/mosaic/mosaic.py
+++ b/mosaic/mosaic.py
@@ -70,6 +70,12 @@ def parse_args():
     parser.add_argument('--query-append', default='',
                         help=('An additional string to be appended to all '
                               'JIRA search queries'))
+    parser.add_argument('--lower-bound', default='0',
+                        help=('A lower bound, below which durations are '
+                              'discarded as anomolous'))
+    parser.add_argument('--upper-bound', default='inf',
+                        help=('An upper bound, above which durations are '
+                              'discarded as anomolous'))
     parser.add_argument('-t', '--types', default=DEFAULT_TYPES,
                         help=('An optional comma separated string argument '
                               'to query for specific types of tickets '
@@ -106,6 +112,8 @@ def run(args, client=None):
         'argument': args['query_argument'],
         'rolling': args.get('rolling', False),
         'query_append': args.get('query_append', ''),
+        'lower_bound': float(args.get('lower_bound', '0')),
+        'upper_bound': float(args.get('upper_bound', 'inf')),
         'types': quoted_types,
     }
 

--- a/mosaic/queries/BaseQuery.py
+++ b/mosaic/queries/BaseQuery.py
@@ -13,6 +13,8 @@ class BaseQuery(object):
         self.result = None
         self.rolling = vars['rolling']
         self.query_append = vars.get('query_append', '')
+        self.lower_bound = float(vars.get('lower_bound', '0'))
+        self.upper_bound = float(vars.get('upper_bound', 'inf'))
         if self.rolling:
             if not self.supports_rolling:
                 msg = ('The specified query: "{query}" does not support the '

--- a/mosaic/queries/StatusdurationQuery.py
+++ b/mosaic/queries/StatusdurationQuery.py
@@ -97,18 +97,19 @@ class StatusdurationQuery(BaseQuery):
         self.log.debug(('{len} issues were completed during the target '
                         'date range.').format(len=issues))
         total_duration = 0
-        for issue in self.results['statusduration']:
-            duration = self._get_time_in_status(issue, target_status)
-            if duration < 0:
-                issues = issues - 1
-            else:
-                self.log.debug(('Time spent in status "{status}" for issue '
-                                '"{key}: {duration} '
-                                'days').format(status=target_status,
-                                               key=issue.key,
-                                               duration=duration))
-                total_duration += duration
-        if self.rolling:
+        if not self.rolling:
+            for issue in self.results['statusduration']:
+                duration = self._get_time_in_status(issue, target_status)
+                if duration < 0:
+                    issues = issues - 1
+                else:
+                    self.log.debug(('Time spent in status "{status}" for '
+                                    'issue {key}: {duration} '
+                                    'days').format(status=target_status,
+                                                   key=issue.key,
+                                                   duration=duration))
+                    total_duration += duration
+        else:
             self.log.debug(('Rolling argument specified. Issues in progress '
                             'will be used to calculate status duration.'))
             self.log.debug(('{len} issues are currently in '

--- a/mosaic/queries/StatusdurationQuery.py
+++ b/mosaic/queries/StatusdurationQuery.py
@@ -116,14 +116,17 @@ class StatusdurationQuery(BaseQuery):
                             'progress.').format(len=len(in_progress_issues)))
             for issue in in_progress_issues:
                 duration = self._get_time_in_status(issue, target_status)
-                if duration >= 0:
-                    self.log.debug(('Time spent in status "{status}" for '
-                                    'issue "{key}: {duration} '
-                                    'days').format(status=target_status,
-                                                   key=issue.key,
-                                                   duration=duration))
-                    total_duration += duration
-                    issues += 1
+                if duration < self.vars['lower_bound']:
+                    continue
+                if duration > self.vars['upper_bound']:
+                    continue
+                self.log.debug(('Time spent in status "{status}" for '
+                                'issue "{key}: {duration} '
+                                'days').format(status=target_status,
+                                               key=issue.key,
+                                               duration=duration))
+                total_duration += duration
+                issues += 1
 
         start_date = self.vars['begin_date']
         end_date = self.vars['end_date']


### PR DESCRIPTION
Please review #29 first.

This one allows excluding outliers.

i.e., anything that passes through a state in 0.01 of a day, which likely
corresponds with someone forgetting to update the state of their card and
fast-tracking it through code review long after the code review is really done.

Or, i.e., anything that passes through a state in 200 days, which likely
corresponds with someone forgetting to close or move a card forwards long after
the action is actually done.
